### PR TITLE
Kadir Has Anadolu Lisesi konumunu Sivas olarak düzeltildi

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Türkiye'nin yedi coğrafi bölgesinden birer lise ile gerçekleştirilen kapsam
 | **Marmara**      | Göztepe İhsan Kurşunoğlu Anadolu Lisesi | Bilecik   | 500     | `#D76A6A`  |
 | **Ege**          | TEB Ataşehir Anadolu Lisesi             | İzmir     | 450     | `#C792EA`  |
 | **Akdeniz**      | Atatürk Fen Lisesi                      | Antalya   | 600     | `#FFD54F`  |
-| **İç Anadolu**   | Kadir Has Anadolu Lisesi                | Ankara    | 550     | `#FF9F4F`  |
+| **İç Anadolu**   | Kadir Has Anadolu Lisesi                | Sivas     | 550     | `#FF9F4F`  |
 | **Karadeniz**    | Kadıköy Anadolu Lisesi                  | Trabzon   | 400     | `#66BB6A`  |
 | **Doğu Anadolu** | Erenköy Kız Anadolu Lisesi              | Elazığ    | 350     | `#81C4E8`  |
 | **Güneydoğu**    | Hayrullah Kefoğlu Anadolu Lisesi        | Gaziantep | 480     | `#BC8F8F`  |

--- a/script.js
+++ b/script.js
@@ -122,7 +122,7 @@ const regionData = {
     'ic-anadolu': {
         name: 'İç Anadolu Bölgesi',
         school: 'Kadir Has Anadolu Lisesi',
-        location: 'Ankara',
+        location: 'Sivas',
         coordinator: false,
         description: 'İç Anadolu, Türkiye\'nin merkezi bölgesidir. Ankara başta olmak üzere Konya, Kayseri gibi tarihi şehirleri barındırır. Bozkır kültürü ve zengin mutfak geleneği vardır.',
         activities: [


### PR DESCRIPTION
İç Anadolu bölgesindeki Kadir Has Anadolu Lisesi'nin konumu yanlışlıkla "Ankara" olarak girilmişti. `script.js` ve `README.md` dosyalarında "Sivas" olarak düzeltildi.

---
_Generated by [Claude Code](https://claude.ai/code/session_01By4qPusLSgDVb3xbVkmjcW)_